### PR TITLE
chore: Remove npx from scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "description": "Zenn content boilerplate",
   "scripts": {
-    "preview": "npx zenn preview",
-    "article": "npx zenn new:article",
-    "book": "npx zenn new:book",
+    "preview": "zenn preview",
+    "article": "zenn new:article",
+    "book": "zenn new:book",
     "update": "yarn add -D zenn-cli@latest",
     "lint:markdown": "markdownlint-cli2 \"**/*.md\"",
     "lint:text": "textlint \"**/*.md\"",


### PR DESCRIPTION
- All dependencies installed in DevContainer
- `zenn` command could not installed using `npx` without `--pacakge` option

少し補足しますと、`npx --package zenn-cli zenn` とすれば新規インストールもできますが、全ての依存関係がインストールされている状況では `npx` 無しで問題ないと考えて削除しました。