### PR TITLE
Fix typo: change 'nmp' to 'npm'

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ VSCodeで複製したリポジトリをクローンして **"Reopen in Container
 
 ### 書くための設定
 
-#### Zenn CLIのコマンドはnmpスクリプトで
+#### Zenn CLIのコマンドはnpmスクリプトで
 
 記事のプレビュー（`npx zenn preview`）や記事の新規作成（`npx zenn new:article`）はnpmスクリプトに登録しています。VSCodeのサイドバーから1クリックで実行できます。
 


### PR DESCRIPTION
### Overview
This pull request addresses a typo in the README.md file. Specifically, it changes "nmp" to "npm".

### Changes Made
- Updated the phrase "Zenn CLI commands are registered as nmp scripts" to "Zenn CLI commands are registered as npm scripts" in README.md.

### Impact
This correction will help users understand the correct command more easily.
