### PR TITLE
Fix lint paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "article": "zenn new:article",
     "book": "zenn new:book",
     "update": "yarn add -D zenn-cli@latest",
-    "lint:markdown": "markdownlint-cli2 \"**/*.md\"",
-    "lint:text": "textlint \"**/*.md\"",
+    "lint:markdown": "markdownlint-cli2 \"articles/*.md\"",
+    "lint:text": "textlint \"articles/*.md\"",
     "lint:prettier": "prettier --ignore-path .prettierignore --check .",
     "lint:cspell": "cspell \"**\" .",
     "prepare": "husky install"


### PR DESCRIPTION
## Description
This pull request updates the lint script paths in `package.json`. Specifically, it changes the paths for `lint:markdown` and `lint:text` to target `articles/*.md`, ensuring the correct directory is being linted.

Changes made:
- Updated `lint:markdown` path to `"articles/*.md"`
- Updated `lint:text` path to `"articles/*.md"`

This fix ensures that the correct files are linted.